### PR TITLE
Change color on hovering 

### DIFF
--- a/src/client/components/pages/index.js
+++ b/src/client/components/pages/index.js
@@ -27,7 +27,7 @@ import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
 import React from 'react';
 import RevisionsTable from './parts/revisions-table';
-import {faXTwitter} from '@fortawesome/free-brands-svg-icons';
+import {faTwitter} from '@fortawesome/free-brands-svg-icons';
 
 
 const {Alert, Button, Col, Container, Row} = bootstrap;
@@ -153,10 +153,10 @@ class IndexPage extends React.Component {
 											<a className="contact-text" href="https://x.com/BookBrainz">
 												<FontAwesomeIcon
 													className="contact-text"
-													icon={faXTwitter}
+													icon={faTwitter}
 													size="2x"
 												/>
-												X
+												Twitter
 											</a>
 											<FontAwesomeIcon
 												className="margin-sides-1 contact-text"

--- a/src/client/components/pages/index.js
+++ b/src/client/components/pages/index.js
@@ -27,7 +27,7 @@ import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
 import React from 'react';
 import RevisionsTable from './parts/revisions-table';
-import {faTwitter} from '@fortawesome/free-brands-svg-icons';
+import {faXTwitter} from '@fortawesome/free-brands-svg-icons';
 
 
 const {Alert, Button, Col, Container, Row} = bootstrap;
@@ -153,10 +153,10 @@ class IndexPage extends React.Component {
 											<a className="contact-text" href="https://x.com/BookBrainz">
 												<FontAwesomeIcon
 													className="contact-text"
-													icon={faTwitter}
+													icon={faXTwitter}
 													size="2x"
 												/>
-												Twitter
+												X
 											</a>
 											<FontAwesomeIcon
 												className="margin-sides-1 contact-text"

--- a/src/client/components/pages/parts/revisions-table.js
+++ b/src/client/components/pages/parts/revisions-table.js
@@ -28,16 +28,16 @@ import {faCodeBranch} from '@fortawesome/free-solid-svg-icons';
 const {Table} = bootstrap;
 const {formatDate, stringToHTMLWithLinks} = utilsHelper;
 
-const handleMouseEnter = (e) => {
-	e.currentTarget.style.color = '';
+function handleMouseEnter(tag){
+	tag.currentTarget.style.color = '';
 };
 
-const handleMouseOver = (e) => {
-	e.currentTarget.style.color = '#963873';
+function handleMouseOver(tag){
+	tag.currentTarget.style.color = '#963873';
 };
 
-const handleMouseOut = (e) => {
-	e.currentTarget.style.color = '';
+function handleMouseOut(tag){
+	tag.currentTarget.style.color = '';
 };
 
 function RevisionsTable(props) {
@@ -79,10 +79,11 @@ function RevisionsTable(props) {
 								results.map((revision) => (
 									<tr key={revision.revisionId}>
 										<td>
-											<a href={`/revision/${revision.revisionId}`}
+											<a 
+												href={`/revision/${revision.revisionId}`}
 												onMouseEnter={handleMouseEnter}
-												onMouseOver={handleMouseOver}
 												onMouseOut={handleMouseOut}
+												onMouseOver={handleMouseOver}
 												title={`${revision.isMerge ? 'Merge revision' : 'Revision'} ${revision.revisionId}`}
 											>
 												#{revision.revisionId}
@@ -104,10 +105,11 @@ function RevisionsTable(props) {
 												<td>
 													{revision.entities.map(entity => (
 														<div key={`${revision.revisionId}-${entity.bbid}`}>
-															<a href={getEntityUrl(entity)}
+															<a 
+																href={getEntityUrl(entity)}
 																onMouseEnter={handleMouseEnter}
-																onMouseOver={handleMouseOver}
-																onMouseOut={handleMouseOut} >
+																onMouseOut={handleMouseOut} 
+																onMouseOver={handleMouseOver}>
 																{genEntityIconHTMLElement(entity.type)}
 																{getEntityLabel(entity)}
 															</a>
@@ -118,10 +120,11 @@ function RevisionsTable(props) {
 										{
 											showRevisionEditor ?
 												<td>
-													<a href={`/editor/${revision.editor.id}`} 
+													<a 
+														href={`/editor/${revision.editor.id}`} 
 														onMouseEnter={handleMouseEnter}
-														onMouseOver={handleMouseOver}
-														onMouseOut={handleMouseOut}>
+														onMouseOut={handleMouseOut}
+														onMouseOver={handleMouseOver}>
 														{revision.editor.name}
 													</a>
 												</td> : null

--- a/src/client/components/pages/parts/revisions-table.js
+++ b/src/client/components/pages/parts/revisions-table.js
@@ -1,4 +1,4 @@
-/*
+/* 
  * Copyright (C) 2020 Prabal Singh
  *
  * This program is free software; you can redistribute it and/or modify
@@ -16,160 +16,143 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import * as bootstrap from 'react-bootstrap';
-import * as utilsHelper from '../../../helpers/utils';
-import {genEntityIconHTMLElement, getEntityLabel, getEntityUrl} from '../../../helpers/entity';
-import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import PropTypes from 'prop-types';
 import React from 'react';
-import {faCodeBranch} from '@fortawesome/free-solid-svg-icons';
+import PropTypes from 'prop-types';
+import * as bootstrap from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCodeBranch } from '@fortawesome/free-solid-svg-icons';
+import * as utilsHelper from '../../../helpers/utils';
+import { genEntityIconHTMLElement, getEntityLabel, getEntityUrl } from '../../../helpers/entity';
 
+const { Table } = bootstrap;
+const { formatDate, stringToHTMLWithLinks } = utilsHelper;
 
-const {Table} = bootstrap;
-const {formatDate, stringToHTMLWithLinks} = utilsHelper;
+const handleMouseEnter = (e) => {
+  	e.currentTarget.style.color = '';
+};
+
+const handleMouseOver = (e) => {
+  	e.currentTarget.style.color = '#963873';
+};
+
+const handleMouseOut = (e) => {
+  	e.currentTarget.style.color = '';
+};
 
 function RevisionsTable(props) {
-	const {results, showEntities, showRevisionNote, showRevisionEditor, tableHeading} = props;
+	const { results, showEntities, showRevisionNote, showRevisionEditor, tableHeading } = props;
+
 	return (
 		<div>
-			<div>
-				<h1 className="text-center">{tableHeading}</h1>
-			</div>
-			<hr className="thin"/>
-			{
-				results.length > 0 ?
-					<Table
-						borderless
-						responsive
-						striped
-					>
-						<thead>
-							<tr>
-								<th width="16%">Revision ID</th>
-								{
-									showEntities ?
-										<th width="42%">Modified entities</th> : null
-								}
-								{
-									showRevisionEditor ?
-										<th width="25%">User</th> : null
-								}
-								{
-									showRevisionNote ?
-										<th width="16%">Note</th> : null
-								}
-								<th width="16%">Date</th>
-							</tr>
-						</thead>
-
-						<tbody>
-							{results.map((revision) => (
-								<tr key={revision.revisionId}>
-								<td>
-									<a
-									href={`/revision/${revision.revisionId}`}
-									onMouseEnter={handleMouseEnter}
-									onMouseOver={handleMouseOver}
-									onMouseOut={handleMouseOut}
-									style={{ color: 'rgb(78,126,194)' }}
-									title={`${revision.isMerge ? 'Merge revision' : 'Revision'} ${revision.revisionId}`}
-									>
-									#{revision.revisionId}
-									{revision.isMerge && (
-										<span className="round-color-icon" style={{ marginLeft: '0.5em' }}>
-										<FontAwesomeIcon flip="vertical" icon={faCodeBranch} transform="shrink-4" />
-										</span>
-									)}
-									</a>
-								</td>
-								{showEntities && (
-									<td>
-									{revision.entities.map((entity) => (
-										<div key={`${revision.revisionId}-${entity.bbid}`}>
-										<a
-											href={getEntityUrl(entity)}
-											onMouseEnter={handleMouseEnter}
-											onMouseOver={handleMouseOver}
-											onMouseOut={handleMouseOut}
-											style={{ color: 'rgb(78,126,194)' }}
-										>
-											{genEntityIconHTMLElement(entity.type)}
-											{getEntityLabel(entity)}
-										</a>
-										</div>
-									))}
-									</td>
-								)}
-								{showRevisionEditor && (
-									<td>
-									<a
-										href={`/editor/${revision.editor.id}`}
-										onMouseEnter={handleMouseEnter}
-										onMouseOver={handleMouseOver}
-										onMouseOut={handleMouseOut}
-										style={{ color: 'rgb(78,126,194)' }}
-									>
-										{revision.editor.name}
-									</a>
-									</td>
-								)}
-								{showRevisionNote && (
-									<td>
-									{revision.notes.map((note) => (
-										<div className="revision-note clearfix" key={note.id}>
-										<span className="note-content">
-											{stringToHTMLWithLinks(note.content)}
-											<a className="note-author float-right" href={`/editor/${note.author.id}`}>
-											—{note.author.name}
-											</a>
-										</span>
-										</div>
-									))}
-									</td>
-								)}
-								<td>{formatDate(new Date(revision.createdAt), true)}</td>
-								</tr>
-							))}
-							</tbody>
-					</Table> :
-
-					<div>
-						<h4> No revisions to show</h4>
-						<hr className="wide"/>
-					</div>
-			}
+		<div>
+			<h1 className="text-center">{tableHeading}</h1>
 		</div>
-
+		<hr className="thin" />
+		{results.length > 0 ? (
+			<Table borderless responsive striped>
+			<thead>
+				<tr>
+				<th width="16%">Revision ID</th>
+				{showEntities && <th width="42%">Modified entities</th>}
+				{showRevisionEditor && <th width="25%">User</th>}
+				{showRevisionNote && <th width="16%">Note</th>}
+				<th width="16%">Date</th>
+				</tr>
+			</thead>
+			<tbody>
+				{results.map((revision) => (
+				<tr key={revision.revisionId}>
+					<td>
+					<a
+						href={`/revision/${revision.revisionId}`}
+						onMouseEnter={handleMouseEnter}
+						onMouseOver={handleMouseOver}
+						onMouseOut={handleMouseOut}
+						style={{ color: 'rgb(78,126,194)' }}
+						title={`${revision.isMerge ? 'Merge revision' : 'Revision'} ${revision.revisionId}`}
+					>
+						#{revision.revisionId}
+						{revision.isMerge && (
+						<span className="round-color-icon" style={{ marginLeft: '0.5em' }}>
+							<FontAwesomeIcon flip="vertical" icon={faCodeBranch} transform="shrink-4" />
+						</span>
+						)}
+					</a>
+					</td>
+					{showEntities && (
+					<td>
+						{revision.entities.map((entity) => (
+						<div key={`${revision.revisionId}-${entity.bbid}`}>
+							<a
+							href={getEntityUrl(entity)}
+							onMouseEnter={handleMouseEnter}
+							onMouseOver={handleMouseOver}
+							onMouseOut={handleMouseOut}
+							style={{ color: 'rgb(78,126,194)' }}
+							>
+							{genEntityIconHTMLElement(entity.type)}
+							{getEntityLabel(entity)}
+							</a>
+						</div>
+						))}
+					</td>
+					)}
+					{showRevisionEditor && (
+					<td>
+						<a
+						href={`/editor/${revision.editor.id}`}
+						onMouseEnter={handleMouseEnter}
+						onMouseOver={handleMouseOver}
+						onMouseOut={handleMouseOut}
+						style={{ color: 'rgb(78,126,194)' }}
+						>
+						{revision.editor.name}
+						</a>
+					</td>
+					)}
+					{showRevisionNote && (
+					<td>
+						{revision.notes.map((note) => (
+						<div className="revision-note clearfix" key={note.id}>
+							<span className="note-content">
+							{stringToHTMLWithLinks(note.content)}
+							<a className="note-author float-right" href={`/editor/${note.author.id}`}>
+								—{note.author.name}
+							</a>
+							</span>
+						</div>
+						))}
+					</td>
+					)}
+					<td>{formatDate(new Date(revision.createdAt), true)}</td>
+				</tr>
+				))}
+			</tbody>
+			</Table>
+		) : (
+			<div>
+			<h4>No revisions to show</h4>
+			<hr className="wide" />
+			</div>
+		)}
+		</div>
 	);
 }
 
 RevisionsTable.propTypes = {
-	results: PropTypes.array.isRequired,
-	showEntities: PropTypes.bool,
-	showRevisionEditor: PropTypes.bool,
-	showRevisionNote: PropTypes.bool,
-	tableHeading: PropTypes.node
+  results: PropTypes.array.isRequired,
+  showEntities: PropTypes.bool,
+  showRevisionEditor: PropTypes.bool,
+  showRevisionNote: PropTypes.bool,
+  tableHeading: PropTypes.node,
 };
+
 RevisionsTable.defaultProps = {
-	showEntities: false,
-	showRevisionEditor: false,
-	showRevisionNote: false,
-	tableHeading: 'Recent Activity'
-
+  showEntities: false,
+  showRevisionEditor: false,
+  showRevisionNote: false,
+  tableHeading: 'Recent Activity',
 };
-
-
-const handleMouseEnter = (e) => {
-	e.currentTarget.style.color = '';
-	};
-
-	const handleMouseOver = (e) => {
-	e.currentTarget.style.color = '#963873';
-	};
-
-	const handleMouseOut = (e) => {
-	e.currentTarget.style.color = '';
-	};
 
 RevisionsTable.displayName = 'RevisionsTable';
 

--- a/src/client/components/pages/parts/revisions-table.js
+++ b/src/client/components/pages/parts/revisions-table.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2020 Prabal Singh
  *
  * This program is free software; you can redistribute it and/or modify
@@ -16,142 +16,166 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import React from 'react';
-import PropTypes from 'prop-types';
 import * as bootstrap from 'react-bootstrap';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCodeBranch } from '@fortawesome/free-solid-svg-icons';
 import * as utilsHelper from '../../../helpers/utils';
-import { genEntityIconHTMLElement, getEntityLabel, getEntityUrl } from '../../../helpers/entity';
+import {genEntityIconHTMLElement, getEntityLabel, getEntityUrl} from '../../../helpers/entity';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {faCodeBranch} from '@fortawesome/free-solid-svg-icons';
 
-const { Table } = bootstrap;
-const { formatDate, stringToHTMLWithLinks } = utilsHelper;
+
+const {Table} = bootstrap;
+const {formatDate, stringToHTMLWithLinks} = utilsHelper;
 
 const handleMouseEnter = (e) => {
-  	e.currentTarget.style.color = '';
+	e.currentTarget.style.color = '';
 };
 
 const handleMouseOver = (e) => {
-  	e.currentTarget.style.color = '#963873';
+	e.currentTarget.style.color = '#963873';
 };
 
 const handleMouseOut = (e) => {
-  	e.currentTarget.style.color = '';
+	e.currentTarget.style.color = '';
 };
 
 function RevisionsTable(props) {
-	const { results, showEntities, showRevisionNote, showRevisionEditor, tableHeading } = props;
-
+	const {results, showEntities, showRevisionNote, showRevisionEditor, tableHeading} = props;
 	return (
 		<div>
-		<div>
-			<h1 className="text-center">{tableHeading}</h1>
-		</div>
-		<hr className="thin" />
-		{results.length > 0 ? (
-			<Table borderless responsive striped>
-			<thead>
-				<tr>
-				<th width="16%">Revision ID</th>
-				{showEntities && <th width="42%">Modified entities</th>}
-				{showRevisionEditor && <th width="25%">User</th>}
-				{showRevisionNote && <th width="16%">Note</th>}
-				<th width="16%">Date</th>
-				</tr>
-			</thead>
-			<tbody>
-				{results.map((revision) => (
-				<tr key={revision.revisionId}>
-					<td>
-					<a
-						href={`/revision/${revision.revisionId}`}
-						onMouseEnter={handleMouseEnter}
-						onMouseOver={handleMouseOver}
-						onMouseOut={handleMouseOut}
-						style={{ color: 'rgb(78,126,194)' }}
-						title={`${revision.isMerge ? 'Merge revision' : 'Revision'} ${revision.revisionId}`}
-					>
-						#{revision.revisionId}
-						{revision.isMerge && (
-						<span className="round-color-icon" style={{ marginLeft: '0.5em' }}>
-							<FontAwesomeIcon flip="vertical" icon={faCodeBranch} transform="shrink-4" />
-						</span>
-						)}
-					</a>
-					</td>
-					{showEntities && (
-					<td>
-						{revision.entities.map((entity) => (
-						<div key={`${revision.revisionId}-${entity.bbid}`}>
-							<a
-							href={getEntityUrl(entity)}
-							onMouseEnter={handleMouseEnter}
-							onMouseOver={handleMouseOver}
-							onMouseOut={handleMouseOut}
-							style={{ color: 'rgb(78,126,194)' }}
-							>
-							{genEntityIconHTMLElement(entity.type)}
-							{getEntityLabel(entity)}
-							</a>
-						</div>
-						))}
-					</td>
-					)}
-					{showRevisionEditor && (
-					<td>
-						<a
-						href={`/editor/${revision.editor.id}`}
-						onMouseEnter={handleMouseEnter}
-						onMouseOver={handleMouseOver}
-						onMouseOut={handleMouseOut}
-						style={{ color: 'rgb(78,126,194)' }}
-						>
-						{revision.editor.name}
-						</a>
-					</td>
-					)}
-					{showRevisionNote && (
-					<td>
-						{revision.notes.map((note) => (
-						<div className="revision-note clearfix" key={note.id}>
-							<span className="note-content">
-							{stringToHTMLWithLinks(note.content)}
-							<a className="note-author float-right" href={`/editor/${note.author.id}`}>
-								—{note.author.name}
-							</a>
-							</span>
-						</div>
-						))}
-					</td>
-					)}
-					<td>{formatDate(new Date(revision.createdAt), true)}</td>
-				</tr>
-				))}
-			</tbody>
-			</Table>
-		) : (
 			<div>
-			<h4>No revisions to show</h4>
-			<hr className="wide" />
+				<h1 className="text-center">{tableHeading}</h1>
 			</div>
-		)}
+			<hr className="thin"/>
+			{
+				results.length > 0 ?
+					<Table
+						borderless
+						responsive
+						striped
+					>
+						<thead>
+							<tr>
+								<th width="16%">Revision ID</th>
+								{
+									showEntities ?
+										<th width="42%">Modified entities</th> : null
+								}
+								{
+									showRevisionEditor ?
+										<th width="25%">User</th> : null
+								}
+								{
+									showRevisionNote ?
+										<th width="16%">Note</th> : null
+								}
+								<th width="16%">Date</th>
+							</tr>
+						</thead>
+
+						<tbody>
+							{
+								results.map((revision) => (
+									<tr key={revision.revisionId}>
+										<td>
+											<a href={`/revision/${revision.revisionId}`}
+												onMouseEnter={handleMouseEnter}
+												onMouseOver={handleMouseOver}
+												onMouseOut={handleMouseOut}
+												title={`${revision.isMerge ? 'Merge revision' : 'Revision'} ${revision.revisionId}`}
+											>
+												#{revision.revisionId}
+												{revision.isMerge &&
+													<span
+														className="round-color-icon"
+														style={{marginLeft: '0.5em'}}
+													>
+														<FontAwesomeIcon
+															flip="vertical" icon={faCodeBranch}
+															transform="shrink-4"
+														/>
+													</span>
+												}
+											</a>
+										</td>
+										{
+											showEntities ?
+												<td>
+													{revision.entities.map(entity => (
+														<div key={`${revision.revisionId}-${entity.bbid}`}>
+															<a href={getEntityUrl(entity)}
+																onMouseEnter={handleMouseEnter}
+																onMouseOver={handleMouseOver}
+																onMouseOut={handleMouseOut} >
+																{genEntityIconHTMLElement(entity.type)}
+																{getEntityLabel(entity)}
+															</a>
+														</div>
+													))}
+												</td> : null
+										}
+										{
+											showRevisionEditor ?
+												<td>
+													<a href={`/editor/${revision.editor.id}`} 
+														onMouseEnter={handleMouseEnter}
+														onMouseOver={handleMouseOver}
+														onMouseOut={handleMouseOut}>
+														{revision.editor.name}
+													</a>
+												</td> : null
+										}
+										{
+											showRevisionNote ?
+												<td>
+													{
+														revision.notes.map(note => (
+															<div className="revision-note clearfix" key={note.id}>
+																<span className="note-content">
+																	{stringToHTMLWithLinks(note.content)}
+																	<a
+																		className="note-author float-right"
+																		href={`/editor/${note.author.id}`}
+																	>
+																		—{note.author.name}
+																	</a>
+																</span>
+															</div>
+														))
+													}
+												</td> : null
+										}
+										<td>{formatDate(new Date(revision.createdAt), true)}</td>
+									</tr>
+								))
+							}
+						</tbody>
+					</Table> :
+
+					<div>
+						<h4> No revisions to show</h4>
+						<hr className="wide"/>
+					</div>
+			}
 		</div>
+
 	);
 }
 
 RevisionsTable.propTypes = {
-  results: PropTypes.array.isRequired,
-  showEntities: PropTypes.bool,
-  showRevisionEditor: PropTypes.bool,
-  showRevisionNote: PropTypes.bool,
-  tableHeading: PropTypes.node,
+	results: PropTypes.array.isRequired,
+	showEntities: PropTypes.bool,
+	showRevisionEditor: PropTypes.bool,
+	showRevisionNote: PropTypes.bool,
+	tableHeading: PropTypes.node
 };
-
 RevisionsTable.defaultProps = {
-  showEntities: false,
-  showRevisionEditor: false,
-  showRevisionNote: false,
-  tableHeading: 'Recent Activity',
+	showEntities: false,
+	showRevisionEditor: false,
+	showRevisionNote: false,
+	tableHeading: 'Recent Activity'
+
 };
 
 RevisionsTable.displayName = 'RevisionsTable';

--- a/src/client/components/pages/parts/revisions-table.js
+++ b/src/client/components/pages/parts/revisions-table.js
@@ -109,7 +109,8 @@ function RevisionsTable(props) {
 																href={getEntityUrl(entity)}
 																onMouseEnter={handleMouseEnter}
 																onMouseOut={handleMouseOut}
-																onMouseOver={handleMouseOver}>
+																onMouseOver={handleMouseOver}
+															>
 																{genEntityIconHTMLElement(entity.type)}
 																{getEntityLabel(entity)}
 															</a>
@@ -120,11 +121,12 @@ function RevisionsTable(props) {
 										{
 											showRevisionEditor ?
 												<td>
-													<a 
+													<a
 														href={`/editor/${revision.editor.id}`}
 														onMouseEnter={handleMouseEnter}
 														onMouseOut={handleMouseOut}
-														onMouseOver={handleMouseOver}>
+														onMouseOver={handleMouseOver}
+													>
 														{revision.editor.name}
 													</a>
 												</td> : null

--- a/src/client/components/pages/parts/revisions-table.js
+++ b/src/client/components/pages/parts/revisions-table.js
@@ -28,17 +28,17 @@ import {faCodeBranch} from '@fortawesome/free-solid-svg-icons';
 const {Table} = bootstrap;
 const {formatDate, stringToHTMLWithLinks} = utilsHelper;
 
-function handleMouseEnter(tag){
+function handleMouseEnter(tag) {
 	tag.currentTarget.style.color = '';
-};
+}
 
-function handleMouseOver(tag){
+function handleMouseOver(tag) {
 	tag.currentTarget.style.color = '#963873';
-};
+}
 
-function handleMouseOut(tag){
+function handleMouseOut(tag) {
 	tag.currentTarget.style.color = '';
-};
+}
 
 function RevisionsTable(props) {
 	const {results, showEntities, showRevisionNote, showRevisionEditor, tableHeading} = props;
@@ -79,12 +79,12 @@ function RevisionsTable(props) {
 								results.map((revision) => (
 									<tr key={revision.revisionId}>
 										<td>
-											<a 
+											<a
 												href={`/revision/${revision.revisionId}`}
+												title={`${revision.isMerge ? 'Merge revision' : 'Revision'} ${revision.revisionId}`}
 												onMouseEnter={handleMouseEnter}
 												onMouseOut={handleMouseOut}
 												onMouseOver={handleMouseOver}
-												title={`${revision.isMerge ? 'Merge revision' : 'Revision'} ${revision.revisionId}`}
 											>
 												#{revision.revisionId}
 												{revision.isMerge &&
@@ -105,10 +105,10 @@ function RevisionsTable(props) {
 												<td>
 													{revision.entities.map(entity => (
 														<div key={`${revision.revisionId}-${entity.bbid}`}>
-															<a 
+															<a
 																href={getEntityUrl(entity)}
 																onMouseEnter={handleMouseEnter}
-																onMouseOut={handleMouseOut} 
+																onMouseOut={handleMouseOut}
 																onMouseOver={handleMouseOver}>
 																{genEntityIconHTMLElement(entity.type)}
 																{getEntityLabel(entity)}
@@ -121,7 +121,7 @@ function RevisionsTable(props) {
 											showRevisionEditor ?
 												<td>
 													<a 
-														href={`/editor/${revision.editor.id}`} 
+														href={`/editor/${revision.editor.id}`}
 														onMouseEnter={handleMouseEnter}
 														onMouseOut={handleMouseOut}
 														onMouseOver={handleMouseOver}>

--- a/src/client/components/pages/parts/revisions-table.js
+++ b/src/client/components/pages/parts/revisions-table.js
@@ -69,6 +69,10 @@ function RevisionsTable(props) {
 										<td>
 											<a
 												href={`/revision/${revision.revisionId}`}
+												onMouseEnter={(e) => e.currentTarget.style.color = ''}
+												onMouseOver={(e) => e.currentTarget.style.color = '#963873'}
+												onMouseOut={(e) => e.currentTarget.style.color = ''}
+												style={{ color: 'rgb(78,126,194)' }}
 												title={`${revision.isMerge ? 'Merge revision' : 'Revision'} ${revision.revisionId}`}
 											>
 												#{revision.revisionId}
@@ -88,9 +92,14 @@ function RevisionsTable(props) {
 										{
 											showEntities ?
 												<td>
-													{revision.entities.map(entity => (
+													{revision.entities.map(entity => (	
 														<div key={`${revision.revisionId}-${entity.bbid}`}>
-															<a href={getEntityUrl(entity)} >
+															<a href={getEntityUrl(entity)}
+															onMouseEnter={(e) => e.currentTarget.style.color = ''}
+															onMouseOver={(e) => e.currentTarget.style.color = '#963873'}
+															onMouseOut={(e) => e.currentTarget.style.color = ''}
+															style={{ color: 'rgb(78,126,194)' }}
+														>
 																{genEntityIconHTMLElement(entity.type)}
 																{getEntityLabel(entity)}
 															</a>
@@ -101,7 +110,11 @@ function RevisionsTable(props) {
 										{
 											showRevisionEditor ?
 												<td>
-													<a href={`/editor/${revision.editor.id}`} >
+													<a href={`/editor/${revision.editor.id}`} 
+													onMouseEnter={(e) => e.currentTarget.style.color = ''}
+													onMouseOver={(e) => e.currentTarget.style.color = '#963873'}
+													onMouseOut={(e) => e.currentTarget.style.color = ''}
+													style={{ color: 'rgb(78,126,194)' }}>
 														{revision.editor.name}
 													</a>
 												</td> : null

--- a/src/client/components/pages/parts/revisions-table.js
+++ b/src/client/components/pages/parts/revisions-table.js
@@ -63,87 +63,74 @@ function RevisionsTable(props) {
 						</thead>
 
 						<tbody>
-							{
-								results.map((revision) => (
-									<tr key={revision.revisionId}>
-										<td>
-											<a
-												href={`/revision/${revision.revisionId}`}
-												onMouseEnter={(e) => e.currentTarget.style.color = ''}
-												onMouseOver={(e) => e.currentTarget.style.color = '#963873'}
-												onMouseOut={(e) => e.currentTarget.style.color = ''}
-												style={{ color: 'rgb(78,126,194)' }}
-												title={`${revision.isMerge ? 'Merge revision' : 'Revision'} ${revision.revisionId}`}
-											>
-												#{revision.revisionId}
-												{revision.isMerge &&
-													<span
-														className="round-color-icon"
-														style={{marginLeft: '0.5em'}}
-													>
-														<FontAwesomeIcon
-															flip="vertical" icon={faCodeBranch}
-															transform="shrink-4"
-														/>
-													</span>
-												}
+							{results.map((revision) => (
+								<tr key={revision.revisionId}>
+								<td>
+									<a
+									href={`/revision/${revision.revisionId}`}
+									onMouseEnter={handleMouseEnter}
+									onMouseOver={handleMouseOver}
+									onMouseOut={handleMouseOut}
+									style={{ color: 'rgb(78,126,194)' }}
+									title={`${revision.isMerge ? 'Merge revision' : 'Revision'} ${revision.revisionId}`}
+									>
+									#{revision.revisionId}
+									{revision.isMerge && (
+										<span className="round-color-icon" style={{ marginLeft: '0.5em' }}>
+										<FontAwesomeIcon flip="vertical" icon={faCodeBranch} transform="shrink-4" />
+										</span>
+									)}
+									</a>
+								</td>
+								{showEntities && (
+									<td>
+									{revision.entities.map((entity) => (
+										<div key={`${revision.revisionId}-${entity.bbid}`}>
+										<a
+											href={getEntityUrl(entity)}
+											onMouseEnter={handleMouseEnter}
+											onMouseOver={handleMouseOver}
+											onMouseOut={handleMouseOut}
+											style={{ color: 'rgb(78,126,194)' }}
+										>
+											{genEntityIconHTMLElement(entity.type)}
+											{getEntityLabel(entity)}
+										</a>
+										</div>
+									))}
+									</td>
+								)}
+								{showRevisionEditor && (
+									<td>
+									<a
+										href={`/editor/${revision.editor.id}`}
+										onMouseEnter={handleMouseEnter}
+										onMouseOver={handleMouseOver}
+										onMouseOut={handleMouseOut}
+										style={{ color: 'rgb(78,126,194)' }}
+									>
+										{revision.editor.name}
+									</a>
+									</td>
+								)}
+								{showRevisionNote && (
+									<td>
+									{revision.notes.map((note) => (
+										<div className="revision-note clearfix" key={note.id}>
+										<span className="note-content">
+											{stringToHTMLWithLinks(note.content)}
+											<a className="note-author float-right" href={`/editor/${note.author.id}`}>
+											—{note.author.name}
 											</a>
-										</td>
-										{
-											showEntities ?
-												<td>
-													{revision.entities.map(entity => (	
-														<div key={`${revision.revisionId}-${entity.bbid}`}>
-															<a href={getEntityUrl(entity)}
-															onMouseEnter={(e) => e.currentTarget.style.color = ''}
-															onMouseOver={(e) => e.currentTarget.style.color = '#963873'}
-															onMouseOut={(e) => e.currentTarget.style.color = ''}
-															style={{ color: 'rgb(78,126,194)' }}
-														>
-																{genEntityIconHTMLElement(entity.type)}
-																{getEntityLabel(entity)}
-															</a>
-														</div>
-													))}
-												</td> : null
-										}
-										{
-											showRevisionEditor ?
-												<td>
-													<a href={`/editor/${revision.editor.id}`} 
-													onMouseEnter={(e) => e.currentTarget.style.color = ''}
-													onMouseOver={(e) => e.currentTarget.style.color = '#963873'}
-													onMouseOut={(e) => e.currentTarget.style.color = ''}
-													style={{ color: 'rgb(78,126,194)' }}>
-														{revision.editor.name}
-													</a>
-												</td> : null
-										}
-										{
-											showRevisionNote ?
-												<td>
-													{
-														revision.notes.map(note => (
-															<div className="revision-note clearfix" key={note.id}>
-																<span className="note-content">
-																	{stringToHTMLWithLinks(note.content)}
-																	<a
-																		className="note-author float-right"
-																		href={`/editor/${note.author.id}`}
-																	>
-																		—{note.author.name}
-																	</a>
-																</span>
-															</div>
-														))
-													}
-												</td> : null
-										}
-										<td>{formatDate(new Date(revision.createdAt), true)}</td>
-									</tr>
-								))
-							}
-						</tbody>
+										</span>
+										</div>
+									))}
+									</td>
+								)}
+								<td>{formatDate(new Date(revision.createdAt), true)}</td>
+								</tr>
+							))}
+							</tbody>
 					</Table> :
 
 					<div>
@@ -170,6 +157,19 @@ RevisionsTable.defaultProps = {
 	tableHeading: 'Recent Activity'
 
 };
+
+
+const handleMouseEnter = (e) => {
+	e.currentTarget.style.color = '';
+	};
+
+	const handleMouseOver = (e) => {
+	e.currentTarget.style.color = '#963873';
+	};
+
+	const handleMouseOut = (e) => {
+	e.currentTarget.style.color = '';
+	};
 
 RevisionsTable.displayName = 'RevisionsTable';
 

--- a/src/server/helpers/middleware.ts
+++ b/src/server/helpers/middleware.ts
@@ -256,7 +256,7 @@ export function checkValidTypeId(req: $Request, res: $Response, next: NextFuncti
 export function checkValidEntityType(req: $Request, res: $Response, next: NextFunction, entityType: string) {
 	const entityTypes = ENTITY_TYPES.map(entity => _.snakeCase(entity));
 	if (!_.includes(entityTypes, entityType)) {
-		return next(new error.BadRequestError(`Invalid Entity Type: ${commonUtils.snakeCaseToSentenceCase(entityType)}`, req));
+		return next(new error.BadRequestError(`Invalid Entity Type: ${_.startCase(entityType)}`, req));
 	}
 	return next();
 }


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing: https://github.com/metabrainz/guidelines/blob/master/GitHub.md
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve?
Add the JIRA ticket number if you are working on one -->
Hovering on to the Entries in Revision id,Modified entities and user should change the color to Rogue color (#963873).

### Solution
<!-- What does this PR do to fix the problem? -->
Added some props to the anchor tags of revision table.

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
The appearance of the revision table is changed providing better contrast.