### PR TITLE
Change color on hovering 

### DIFF
--- a/src/client/components/pages/about.tsx
+++ b/src/client/components/pages/about.tsx
@@ -20,7 +20,7 @@ import {faCircle, faCommentDots, faComments, faEnvelope} from '@fortawesome/free
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 
 import React from 'react';
-import {faXTwitter} from '@fortawesome/free-brands-svg-icons';
+import {faTwitter} from '@fortawesome/free-brands-svg-icons';
 
 
 /**
@@ -114,10 +114,10 @@ function AboutPage(): JSX.Element {
 				<a className="contact-text" href="https://x.com/BookBrainz">
 					<FontAwesomeIcon
 						className="contact-text"
-						icon={faXTwitter}
+						icon={faTwitter}
 						size="2x"
 					/>
-					X
+					Twitter
 				</a>
 				<FontAwesomeIcon
 					className="margin-sides-1 contact-text"

--- a/src/client/components/pages/about.tsx
+++ b/src/client/components/pages/about.tsx
@@ -20,7 +20,7 @@ import {faCircle, faCommentDots, faComments, faEnvelope} from '@fortawesome/free
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 
 import React from 'react';
-import {faTwitter} from '@fortawesome/free-brands-svg-icons';
+import {faXTwitter} from '@fortawesome/free-brands-svg-icons';
 
 
 /**
@@ -114,10 +114,10 @@ function AboutPage(): JSX.Element {
 				<a className="contact-text" href="https://x.com/BookBrainz">
 					<FontAwesomeIcon
 						className="contact-text"
-						icon={faTwitter}
+						icon={faXTwitter}
 						size="2x"
 					/>
-					Twitter
+					X
 				</a>
 				<FontAwesomeIcon
 					className="margin-sides-1 contact-text"

--- a/src/client/components/pages/index.js
+++ b/src/client/components/pages/index.js
@@ -27,7 +27,7 @@ import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
 import React from 'react';
 import RevisionsTable from './parts/revisions-table';
-import {faXTwitter} from '@fortawesome/free-brands-svg-icons';
+import {faTwitter} from '@fortawesome/free-brands-svg-icons';
 
 
 const {Alert, Button, Col, Container, Row} = bootstrap;
@@ -153,10 +153,10 @@ class IndexPage extends React.Component {
 											<a className="contact-text" href="https://x.com/BookBrainz">
 												<FontAwesomeIcon
 													className="contact-text"
-													icon={faXTwitter}
+													icon={faTwitter}
 													size="2x"
 												/>
-												X
+												Twitter
 											</a>
 											<FontAwesomeIcon
 												className="margin-sides-1 contact-text"

--- a/src/client/components/pages/parts/revisions-table.js
+++ b/src/client/components/pages/parts/revisions-table.js
@@ -28,6 +28,18 @@ import {faCodeBranch} from '@fortawesome/free-solid-svg-icons';
 const {Table} = bootstrap;
 const {formatDate, stringToHTMLWithLinks} = utilsHelper;
 
+function handleMouseEnter(tag) {
+	tag.currentTarget.style.color = '';
+}
+
+function handleMouseOver(tag) {
+	tag.currentTarget.style.color = '#963873';
+}
+
+function handleMouseOut(tag) {
+	tag.currentTarget.style.color = '';
+}
+
 function RevisionsTable(props) {
 	const {results, showEntities, showRevisionNote, showRevisionEditor, tableHeading} = props;
 	return (
@@ -70,6 +82,9 @@ function RevisionsTable(props) {
 											<a
 												href={`/revision/${revision.revisionId}`}
 												title={`${revision.isMerge ? 'Merge revision' : 'Revision'} ${revision.revisionId}`}
+												onMouseEnter={handleMouseEnter}
+												onMouseOut={handleMouseOut}
+												onMouseOver={handleMouseOver}
 											>
 												#{revision.revisionId}
 												{revision.isMerge &&
@@ -90,7 +105,12 @@ function RevisionsTable(props) {
 												<td>
 													{revision.entities.map(entity => (
 														<div key={`${revision.revisionId}-${entity.bbid}`}>
-															<a href={getEntityUrl(entity)} >
+															<a
+																href={getEntityUrl(entity)}
+																onMouseEnter={handleMouseEnter}
+																onMouseOut={handleMouseOut}
+																onMouseOver={handleMouseOver}
+															>
 																{genEntityIconHTMLElement(entity.type)}
 																{getEntityLabel(entity)}
 															</a>
@@ -101,7 +121,12 @@ function RevisionsTable(props) {
 										{
 											showRevisionEditor ?
 												<td>
-													<a href={`/editor/${revision.editor.id}`} >
+													<a
+														href={`/editor/${revision.editor.id}`}
+														onMouseEnter={handleMouseEnter}
+														onMouseOut={handleMouseOut}
+														onMouseOver={handleMouseOver}
+													>
 														{revision.editor.name}
 													</a>
 												</td> : null

--- a/src/server/helpers/middleware.ts
+++ b/src/server/helpers/middleware.ts
@@ -256,7 +256,7 @@ export function checkValidTypeId(req: $Request, res: $Response, next: NextFuncti
 export function checkValidEntityType(req: $Request, res: $Response, next: NextFunction, entityType: string) {
 	const entityTypes = ENTITY_TYPES.map(entity => _.snakeCase(entity));
 	if (!_.includes(entityTypes, entityType)) {
-		return next(new error.BadRequestError(`Invalid Entity Type: ${commonUtils.snakeCaseToSentenceCase(entityType)}`, req));
+		return next(new error.BadRequestError(`Invalid Entity Type: ${_.startCase(entityType)}`, req));
 	}
 	return next();
 }


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing: https://github.com/metabrainz/guidelines/blob/master/GitHub.md
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve?
Add the JIRA ticket number if you are working on one -->
Currently, the entries in the Revision ID and Modified entities columns do not change color when hovered over, making it difficult for users to identify which entry they are selecting.

### Solution
<!-- What does this PR do to fix the problem? -->
This pull request introduces a change to the CSS to modify the hover behavior. When a user hovers over an entry in the Revision ID or Modified entities columns, the text color changes to Rogue color (#963873), enhancing the user experience by providing a visual indication of the selected entry.

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
This change will make it easier for users to navigate and interact with the table, improving overall accessibility.

Here's what it's gonna look like when hovering: 
https://github.com/yogiyadav13/bookbrainz/assets/149246660/a0cbb142-a0f7-4fe0-a3f3-071919027d08